### PR TITLE
Subscribers and retryer events

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -24,3 +24,6 @@
 gen/*
 !gen/.keep
 temp/*
+
+# fork description file
+description.txt

--- a/cfg/config.go
+++ b/cfg/config.go
@@ -84,7 +84,13 @@ type samplePGDatabase struct {
 
 type consumers struct {
 	SamplePG samplePGDatabase `mapstructure:"sample-db" yaml:"sample-db"`
+	// Notifier telegram
 }
+
+// type telegram struct {
+// 	Token  string
+// 	ChatID int
+// }
 
 func (c consumers) MarshalZerologObject(e *zerolog.Event) {
 	e.Str("sample-db", c.SamplePG.URI)
@@ -224,21 +230,14 @@ func (c consumers) Subscribers() (subs []event.Subscriber, err error) {
 	if err != nil {
 		return nil, err
 	}
+	/*
+		telegram, err := c.Notifier.Subscriber()
+		if err != nil {
+			return nil, err
+		}
+	*/
 	return append(make([]event.Subscriber, 0), postgres), nil
 }
-
-
-// func (c consumers) GetConsumers(l *zerolog.Logger) (lsnr []event.Listener, err error) {
-// 	lsnr = make([]event.Listener, 0)
-// 	sampleDB, err := c.SamplePG.GetConsumer(l)
-// 	if err != nil {
-// 		return nil, fmt.Errorf("get sample db consumer: %w", err)
-// 	}
-// 	if sampleDB != nil {
-// 		lsnr = append(lsnr, sampleDB)
-// 	}
-// 	return lsnr, nil
-// }
 
 func (s samplePGDatabase) Subscriber() (sub event.Subscriber, err error) {
 	if !viper.IsSet("consumers.sample-db.uri") {

--- a/cfg/config.go
+++ b/cfg/config.go
@@ -219,19 +219,28 @@ func (s tcpServer) Validate() error {
 
 /* consumers methods */
 
-func (c consumers) GetConsumers(l *zerolog.Logger) (lsnr []event.Listener, err error) {
-	lsnr = make([]event.Listener, 0)
-	sampleDB, err := c.SamplePG.GetConsumer(l)
+func (c consumers) Subscribers() (subs []event.Subscriber, err error) {
+	postgres, err := c.SamplePG.Subscriber()
 	if err != nil {
-		return nil, fmt.Errorf("get sample db consumer: %w", err)
+		return nil, err
 	}
-	if sampleDB != nil {
-		lsnr = append(lsnr, sampleDB)
-	}
-	return lsnr, nil
+	return append(make([]event.Subscriber, 0), postgres), nil
 }
 
-func (s samplePGDatabase) GetConsumer(l *zerolog.Logger) (lsnr event.Listener, err error) {
+
+// func (c consumers) GetConsumers(l *zerolog.Logger) (lsnr []event.Listener, err error) {
+// 	lsnr = make([]event.Listener, 0)
+// 	sampleDB, err := c.SamplePG.GetConsumer(l)
+// 	if err != nil {
+// 		return nil, fmt.Errorf("get sample db consumer: %w", err)
+// 	}
+// 	if sampleDB != nil {
+// 		lsnr = append(lsnr, sampleDB)
+// 	}
+// 	return lsnr, nil
+// }
+
+func (s samplePGDatabase) Subscriber() (sub event.Subscriber, err error) {
 	if !viper.IsSet("consumers.sample-db.uri") {
 		return nil, nil
 	}
@@ -250,7 +259,7 @@ func (s samplePGDatabase) GetConsumer(l *zerolog.Logger) (lsnr event.Listener, e
 		return nil, fmt.Errorf("ping sample db: %w", err)
 	}
 
-	db, err = sampledb.NewDB(l, p)
+	db, err = sampledb.NewDB(p)
 	if err != nil {
 		return nil, fmt.Errorf("create sample listener: %w", err)
 	}

--- a/cfg/config.go
+++ b/cfg/config.go
@@ -136,7 +136,7 @@ func (l logging) ZerologLevel() zerolog.Level {
 
 /* player methods */
 
-func (p player) GetOptions() []tcp.ReplayerOption {
+func (p player) Options() []tcp.ReplayerOption {
 	o := make([]tcp.ReplayerOption, 0, 2)
 	if viper.IsSet("player.delay") {
 		o = append(o, tcp.WithDelay(p.Delay))
@@ -149,7 +149,7 @@ func (p player) GetOptions() []tcp.ReplayerOption {
 
 // GetProtocol returns tcp.Protocol for bufio.Scanner.
 // If protocol is not defined it will return bufio.ScanLines.
-func (p player) GetProtocol() tcp.Protocol {
+func (p player) Protocol() tcp.Protocol {
 	var splitFuncs = map[string]tcp.Protocol{
 		wialonips.Proto: wialonips.NewWialonIPS(),
 		egts.Proto:      egts.NewEGTS(),
@@ -179,7 +179,7 @@ func (p player) Validate() error {
 /* tcp server methods */
 
 // GetProtocol returns protocol handler according Proto property.
-func (s tcpServer) GetProtocol() tcp.Protocol {
+func (s tcpServer) Protocol() tcp.Protocol {
 	switch s.Proto {
 	case egts.Proto:
 		return egts.NewEGTS()
@@ -189,7 +189,7 @@ func (s tcpServer) GetProtocol() tcp.Protocol {
 	return egts.NewEGTS()
 }
 
-func (s tcpServer) GetOptions() []tcp.ServerOption {
+func (s tcpServer) Options() []tcp.ServerOption {
 	o := make([]tcp.ServerOption, 0, 2)
 	if viper.IsSet("tcp.timeouts") {
 		o = append(o, tcp.WithTimeout(time.Duration(s.Timeouts)*time.Second))

--- a/cmd/replay.go
+++ b/cmd/replay.go
@@ -54,8 +54,8 @@ var replayCmd = &cobra.Command{
 
 		replayer := tcp.NewReplayer(
 			c.Player.Address,
-			c.Player.GetProtocol(),
-			c.Player.GetOptions()...,
+			c.Player.Protocol(),
+			c.Player.Options()...,
 		)
 		player.Run(c.Player.InPath, c.Player.FileMask, replayer, c.Player.Workers)
 

--- a/cmd/tcp.go
+++ b/cmd/tcp.go
@@ -45,20 +45,12 @@ Example:
 		logger.Info().Object("tcp-server", c.TCPServer).Msg("server config")
 		logger.Info().Object("consumers", c.Consumers).Msg("consumers config")
 
-		srv, err := tcp.NewServer(logger, c.TCPServer.Address, c.TCPServer.GetOptions()...)
+		srv, err := tcp.NewServer(logger, c.TCPServer.Address, c.TCPServer.Options()...)
 		if err != nil {
 			return fmt.Errorf("create tcp server: %w", err)
 		}
 
-		srv.SetProtocol(c.TCPServer.GetProtocol())
-		// cons, err := c.Consumers.GetConsumers(&logger)
-		// if err != nil {
-		// 	return fmt.Errorf("get consumers: %w", err)
-		// }
-
-		// for _, con := range cons {
-		// 	srv.Handler.RegisterEventListener(con)
-		// }
+		srv.SetProtocol(c.TCPServer.Protocol())
 
 		subs, err := c.Consumers.Subscribers()
 		if err != nil {

--- a/cmd/tcp.go
+++ b/cmd/tcp.go
@@ -51,14 +51,24 @@ Example:
 		}
 
 		srv.SetProtocol(c.TCPServer.GetProtocol())
-		cons, err := c.Consumers.GetConsumers(&logger)
+		// cons, err := c.Consumers.GetConsumers(&logger)
+		// if err != nil {
+		// 	return fmt.Errorf("get consumers: %w", err)
+		// }
+
+		// for _, con := range cons {
+		// 	srv.Handler.RegisterEventListener(con)
+		// }
+
+		subs, err := c.Consumers.Subscribers()
 		if err != nil {
-			return fmt.Errorf("get consumers: %w", err)
+			return fmt.Errorf("get events consumers-subscribers: %w", err)
 		}
 
-		for _, con := range cons {
-			srv.Handler.RegisterEventListener(con)
+		for _, sub := range subs {
+			srv.Handler.RegisterEventSubscriber(sub)
 		}
+
 		err = srv.ListenAndServe()
 		if err != nil {
 			return fmt.Errorf("start tcp server: %w", err)

--- a/go.mod
+++ b/go.mod
@@ -11,7 +11,6 @@ require (
 	github.com/maurice2k/tcpserver v1.2.0
 	github.com/peterstace/simplefeatures v0.41.0
 	github.com/rs/zerolog v1.29.0
-	github.com/sigurn/crc16 v0.0.0-20211026045750-20ab5afb07e3
 	github.com/spf13/cobra v1.6.1
 	github.com/spf13/viper v1.15.0
 	github.com/stretchr/testify v1.8.2
@@ -62,6 +61,7 @@ require (
 	github.com/pkg/errors v0.9.1 // indirect
 	github.com/pmezard/go-difflib v1.0.0 // indirect
 	github.com/sagikazarmark/crypt v0.9.0 // indirect
+	github.com/sigurn/crc16 v0.0.0-20211026045750-20ab5afb07e3 // indirect
 	github.com/sigurn/crc8 v0.0.0-20220107193325-2243fe600f9f // indirect
 	github.com/spf13/afero v1.9.5 // indirect
 	github.com/spf13/cast v1.5.0 // indirect

--- a/internal/event/event.go
+++ b/internal/event/event.go
@@ -41,7 +41,9 @@ type Reply struct {
 }
 
 type Name string
+
 const (
 	PositionRecived Name = "position.received"
 	CloseConnection Name = "close.connection"
+	// NotifyError     Name = "notify.error"
 )

--- a/internal/event/event.go
+++ b/internal/event/event.go
@@ -8,13 +8,40 @@ import (
 
 var _ event.Event = (*GenericEvent)(nil)
 
-// GenericEvent describes generic and unified events extracted from received data.
+// GenericEvent wrapper for event.BasicEvent describes generic and unified events.
 type GenericEvent struct {
 	event.BasicEvent
-	common.Position
 }
 
-// GetPosition returns generic and unified position data.
-func (e GenericEvent) GetPosition() common.Position {
-	return e.Position
+// Position returns generic and unified position data.
+func (e GenericEvent) Position() *common.Position {
+	data := e.Data()
+	if len(data) == 0 {
+		return nil
+	}
+	pos, ok := data["position"]
+	if !ok {
+		return nil
+	}
+	position, ok := pos.(common.Position)
+	if !ok {
+		return nil
+	}
+	return &position
 }
+
+// SetPosition adds position data to an event.
+func (e *GenericEvent) SetPosition(pos common.Position) {
+	e.SetData(event.M{"position": pos})
+}
+
+type Reply struct {
+	Error   error
+	Message string
+}
+
+type Name string
+const (
+	PositionRecived Name = "position.received"
+	CloseConnection Name = "close.connection"
+)

--- a/internal/protocol/egts/egts.go
+++ b/internal/protocol/egts/egts.go
@@ -35,7 +35,7 @@ func (e *EGTS) Respond(s *internal.Session, bytes []byte) (res tcp.Result, err e
 	pkg := egts.Packet{}
 	_ = pkg.Decode(bytes)
 
-	device := e.getDevice(&pkg)
+	device := e.device(&pkg)
 	if device != "" {
 		s.SetDevice(device)
 	}
@@ -48,7 +48,7 @@ func (e *EGTS) Respond(s *internal.Session, bytes []byte) (res tcp.Result, err e
 	return
 }
 
-func (e *EGTS) getDevice(pkg *egts.Packet) string {
+func (e *EGTS) device(pkg *egts.Packet) string {
 	if pkg.ServicesFrameData == nil {
 		return ""
 	}

--- a/internal/protocol/wialonips/wialonips.go
+++ b/internal/protocol/wialonips/wialonips.go
@@ -35,7 +35,7 @@ func (w *WialonIPS) NewFrameSplitter() common.FrameSplitter {
 
 // Respond returns the result of parsing the WialonIPS data.
 func (w *WialonIPS) Respond(s *internal.Session, bytes []byte) (res tcp.Result, err error) {
-	pkg := wialonips.NewPacket(w.getVersion(s), s.Device())
+	pkg := wialonips.NewPacket(w.version(s), s.Device())
 	err = pkg.Decode(bytes)
 	if pkg.Type == wialonips.LoginPacket {
 		s.SetDevice(pkg.IMEI)
@@ -54,7 +54,7 @@ func (w *WialonIPS) Respond(s *internal.Session, bytes []byte) (res tcp.Result, 
 	return
 }
 
-func (w *WialonIPS) getVersion(s *internal.Session) wialonips.Version {
+func (w *WialonIPS) version(s *internal.Session) wialonips.Version {
 	val := s.Get(ctxVersion)
 	if val == nil {
 		return wialonips.UnknownVersion

--- a/internal/protocol/wialonips/wialonips.go
+++ b/internal/protocol/wialonips/wialonips.go
@@ -35,7 +35,7 @@ func (w *WialonIPS) NewFrameSplitter() common.FrameSplitter {
 
 // Respond returns the result of parsing the WialonIPS data.
 func (w *WialonIPS) Respond(s *internal.Session, bytes []byte) (res tcp.Result, err error) {
-	pkg := wialonips.NewPacket(w.getVersion(s), s.GetDevice())
+	pkg := wialonips.NewPacket(w.getVersion(s), s.Device())
 	err = pkg.Decode(bytes)
 	if pkg.Type == wialonips.LoginPacket {
 		s.SetDevice(pkg.IMEI)

--- a/internal/sampledb/database.go
+++ b/internal/sampledb/database.go
@@ -2,22 +2,39 @@ package sampledb
 
 import (
 	"context"
+	"fmt"
+	"strings"
 
 	"github.com/gookit/event"
 	ev "github.com/gotrackery/gotrackery/internal/event"
+	
 	"github.com/jackc/pgx/v5"
 	"github.com/jackc/pgx/v5/pgxpool"
-	"github.com/rs/zerolog"
 )
 
-var _ event.Listener = (*DB)(nil)
+var (
+	_ event.Listener   = (*DB)(nil)
+	_ event.Subscriber = (*DB)(nil)
+)
 
 type DB struct {
-	logger *zerolog.Logger
-	db     *pgxpool.Pool
+	// logger *zerolog.Logger
+	db *pgxpool.Pool
 }
 
-func NewDB(l *zerolog.Logger, db *pgxpool.Pool) (*DB, error) {
+const (
+	SELF_NAME = "postgres"
+)
+
+func (d *DB) String() string {
+	return SELF_NAME
+}
+
+func (d *DB) close() {
+	d.db.Close()
+}
+
+func NewDB(db *pgxpool.Pool) (*DB, error) {
 	if db == nil {
 		panic("missing *pgxpool.Pool, parameter must not be nil")
 	}
@@ -27,18 +44,42 @@ func NewDB(l *zerolog.Logger, db *pgxpool.Pool) (*DB, error) {
 		return nil, err
 	}
 
-	return &DB{logger: l, db: db}, nil
+	return &DB{db: db}, nil
+}
+
+func (d *DB) SubscribedEvents() map[string]any {
+	return map[string]any{
+		fmt.Sprintf("%s.%s", ev.PositionRecived, SELF_NAME): d,
+		fmt.Sprintf("%s.%s", ev.CloseConnection, SELF_NAME): d,
+	}
 }
 
 func (d *DB) Handle(e event.Event) (err error) {
-	pos := e.(*ev.GenericEvent).GetPosition()
-	tr, err := CreateFromCommon(pos)
-	if err != nil {
-		return err
+	eve, ok := e.(*ev.GenericEvent)
+	if !ok || eve == nil {
+		return fmt.Errorf("GenericEvent not transferred")
 	}
-	err = d.insert(context.Background(), tr)
-	if err != nil {
-		return
+	name, ok := strings.CutSuffix(eve.Name(), "."+SELF_NAME)
+	if !ok {
+		return fmt.Errorf("event not found for listner: %s", SELF_NAME)
+	}
+	switch name {
+	case string(ev.PositionRecived):
+		pos := eve.Position()
+		if pos == nil {
+			return fmt.Errorf("position not specified")
+		}
+		tr, err := CreateFromCommon(*pos)
+		if err != nil {
+			return fmt.Errorf("create position from common: %w", err)
+		}
+		err = d.insert(context.Background(), tr)
+		if err != nil {
+			return fmt.Errorf("insert position: %w", err)
+		}
+
+	case string(ev.CloseConnection):
+		d.close()
 	}
 
 	return nil

--- a/internal/sampledb/database.go
+++ b/internal/sampledb/database.go
@@ -18,7 +18,6 @@ var (
 )
 
 type DB struct {
-	// logger *zerolog.Logger
 	db *pgxpool.Pool
 }
 

--- a/internal/session.go
+++ b/internal/session.go
@@ -40,7 +40,7 @@ func (s *Session) SetDevice(dev string) {
 }
 
 // GetDevice returns the device id from session context.
-func (s *Session) GetDevice() string {
+func (s *Session) Device() string {
 	if s.ctx == nil {
 		return ""
 	}

--- a/internal/session_test.go
+++ b/internal/session_test.go
@@ -13,13 +13,13 @@ func TestSession(t *testing.T) {
 	assert.Equal(t, s.Get("test"), "test", "Get should return test")
 
 	s = &Session{}
-	assert.Equal(t, s.GetDevice(), "", "GetDevice should return empty string, if not set")
+	assert.Equal(t, s.Device(), "", "Device should return empty string, if not set")
 	s.SetDevice("device")
-	assert.Equal(t, s.GetDevice(), "device", "GetDevice should return device, if set")
+	assert.Equal(t, s.Device(), "device", "Device should return device, if set")
 	s = NewSession()
-	assert.Equal(t, s.GetDevice(), "", "GetDevice should return empty string")
+	assert.Equal(t, s.Device(), "", "Device should return empty string")
 	s.SetDevice("device")
-	assert.Equal(t, s.GetDevice(), "device", "GetDevice should return device")
+	assert.Equal(t, s.Device(), "device", "Device should return device")
 
 	f := func(session *Session) {
 		session.Set("internal", "test")

--- a/internal/tcp/handler.go
+++ b/internal/tcp/handler.go
@@ -2,9 +2,12 @@ package tcp
 
 import (
 	"bufio"
+	"context"
 	"encoding/hex"
 	"errors"
+	"fmt"
 	"io"
+	"strings"
 	"time"
 
 	"github.com/gookit/event"
@@ -15,10 +18,6 @@ import (
 	gonanoid "github.com/matoous/go-nanoid/v2"
 	"github.com/maurice2k/tcpserver"
 	"github.com/rs/zerolog"
-)
-
-const (
-	evName = "generic.position.receive"
 )
 
 // Result is the result of handling bytes packet.
@@ -40,16 +39,42 @@ type Handler struct {
 	evManager   *event.Manager
 }
 
+const (
+	eventManagerName = "events manager"
+)
+
 // NewHandler creates a new tcp protocol handler.
 func NewHandler(l zerolog.Logger, p Protocol, idle time.Duration) (h *Handler) {
-	h = &Handler{logger: l, proto: p, IdleTimeout: idle, evManager: event.NewManager("receiver")}
+	h = &Handler{logger: l, proto: p, IdleTimeout: idle, evManager: event.NewManager(eventManagerName)}
 	return
 }
 
-// RegisterEventListener registers an event listener to get a copy of Event that handler extracted.
-func (h *Handler) RegisterEventListener(listener event.Listener) {
-	h.evManager.AddListener(evName, listener)
+func (h *Handler) RegisterEventSubscriber(sub event.Subscriber) {
+	h.logger.Debug().Str("consumer-listener", fmt.Sprintf("%s", sub)).Msg("register events subscriber")
+	h.evManager.AddSubscriber(sub)
 }
+
+func (h *Handler) subsribersNames() []string {
+	events := h.evManager.ListenedNames()
+	set := make(map[string]struct{}, len(events))
+	for n := range events {
+		names := strings.Split(n, ".")
+		name := names[len(names)-1]
+		if _, ok := set[name]; !ok {
+			set[name] = struct{}{}
+		}
+	}
+	listeners := make([]string, 0)
+	for n := range set {
+		listeners = append(listeners, n)
+	}
+	return listeners
+}
+
+// RegisterEventListener registers an event listener to get a copy of Event that handler extracted.
+// func (h *Handler) RegisterEventListener(listener event.Listener) {
+// 	h.evManager.AddListener(evName, listener)
+// }
 
 // Handle handles the tcp inbound connection.
 // It parses the tcp payload and calls the protocol handler.
@@ -104,7 +129,7 @@ func (h *Handler) handle(l *zerolog.Logger, conn tcpserver.Connection) {
 		if err != nil {
 			l.Warn().Err(err).Msg("got protocol error")
 		}
-		l.Debug().Str("dir", "out").Str("device", session.GetDevice()).Str("bytes", hex.EncodeToString(result.Response)).Send()
+		l.Debug().Str("dir", "out").Str("device", session.Device()).Str("bytes", hex.EncodeToString(result.Response)).Send()
 
 		if len(result.Response) > 0 {
 			_, err = conn.Write(result.Response) // send result even got error
@@ -119,9 +144,18 @@ func (h *Handler) handle(l *zerolog.Logger, conn tcpserver.Connection) {
 		}
 
 		if result.GenericAdapter != nil {
-			err = h.fireEvent(result.GenericAdapter)
-			if err != nil {
-				l.Error().Err(err).Msg("fire event")
+			poss := result.GenericAdapter.GenericPositions()
+			for _, pos := range poss {
+				for _, name := range h.subsribersNames() {
+					e := new(ev.GenericEvent)
+					e.SetPosition(pos)
+					e.SetName(fmt.Sprintf("%s.%s", ev.PositionRecived, name))
+
+					ctx, cancel := context.WithTimeout(context.Background(), h.IdleTimeout)
+					defer cancel()
+					go h.fireEvent(ctx, l, e)
+				}
+
 			}
 		}
 	}
@@ -132,25 +166,64 @@ func (h *Handler) handle(l *zerolog.Logger, conn tcpserver.Connection) {
 	}
 
 	if scanner.Err() != nil && scanner.Err() != io.EOF {
-		l.Error().Err(scanner.Err()).Msg("scanner error")
+		l.Error().Err(scanner.Err()).Msg("scanner error") //error="read tcp4 10.203.44.11:1328->185.9.185.4:38726: i/o timeout"
 		return
 	}
 }
 
-func (h *Handler) fireEvent(adapter gen.Adapter) error {
-	poss := adapter.GenericPositions()
-	for _, pos := range poss {
-		e := &ev.GenericEvent{
-			Position: pos,
-		}
-		e.SetName(evName)
-		err := h.evManager.FireEvent(e)
-		if err != nil {
-			// ToDo log every error separately
-			return err
-		}
-		h.logger.Debug().Str("event", evName).Object("position", pos).Msg("event fired")
-	}
+func (h *Handler) fireEvent(ctx context.Context, l *zerolog.Logger, event event.Event) {
+	reply := make(chan ev.Reply)
+	defer close(reply)
+	retrying := retryFire(ctx, l, h.evManager.FireEvent, reply)
 
-	return nil
+	go retrying(event)
+
+	for r := range reply {
+		if r.Error == nil {
+			l.Info().Msg(r.Message)
+			return
+		}
+		l.Err(r.Error).Msg(r.Message)
+		if r.Error != nil && r.Error == context.Canceled {
+			return
+		}
+		continue
+	}
+}
+
+type fireraiser func(event event.Event) error
+
+func retryFire(ctx context.Context, l *zerolog.Logger, fireraiser fireraiser, reply chan ev.Reply) fireraiser {
+	return func(evnt event.Event) error {
+		for try := 1; ; try++ {
+			err := fireraiser(evnt)
+			if err == nil {
+				reply <- ev.Reply{
+					Message: fmt.Sprintf(`successful handle "%s" event`, evnt.Name()),
+				}
+				return nil
+			}
+
+			/*
+				TODO: in this place, by creating a new event through the fireraiser, you can call the event of some notifier to notify about an error
+			*/
+
+			delay := time.Second << uint(try)
+			timer := time.NewTimer(delay)
+			defer timer.Stop()
+			reply <- ev.Reply{
+				Error:   err,
+				Message: fmt.Sprintf(`event "%s" failed attempt #[%d] | retrying after: [%s]`, evnt.Name(), try, delay),
+			}
+			select {
+			case <-timer.C:
+			case <-ctx.Done():
+				reply <- ev.Reply{
+					Error:   ctx.Err(),
+					Message: fmt.Sprintf(`retrying event "%s" stopped via context`, evnt.Name()),
+				}
+				return ctx.Err()
+			}
+		}
+	}
 }

--- a/internal/tcp/server.go
+++ b/internal/tcp/server.go
@@ -113,6 +113,7 @@ func (s *Server) ListenAndServe() error {
 			e.SetName(fmt.Sprintf("%s.%s", event.CloseConnection, name))
 			go s.Handler.fireEvent(context.Background(), &s.logger, e)
 		}
+		s.srv.Shutdown(s.timeout)
 	}()
 	
 	err := s.srv.Listen()

--- a/internal/tcp/server.go
+++ b/internal/tcp/server.go
@@ -1,9 +1,11 @@
 package tcp
 
 import (
+	"context"
 	"fmt"
 	"time"
 
+	"github.com/gotrackery/gotrackery/internal/event"
 	"github.com/maurice2k/tcpserver"
 	"github.com/rs/zerolog"
 )
@@ -105,6 +107,14 @@ func (s *Server) SetProtocol(p Protocol) {
 
 // ListenAndServe starts the TCP server.
 func (s *Server) ListenAndServe() error {
+	defer func(){
+		for _, name := range s.Handler.subsribersNames() {
+			e := new(event.GenericEvent)
+			e.SetName(fmt.Sprintf("%s.%s", event.CloseConnection, name))
+			go s.Handler.fireEvent(context.Background(), &s.logger, e)
+		}
+	}()
+	
 	err := s.srv.Listen()
 
 	if err != nil {


### PR DESCRIPTION
The event.Subscriber interface is implemented for the consumer.
It allows you to subscribe a consumer to events intended only for him.
The Handle consumer method implements routing of its own events. When an event occurs, the consumer will only respond to the event for which it is subscribed.

An event name type has been added to the internal event package. This type allows consumers to subscribe to these events.
The GenericEvent type has been changed - the common.Position field has been removed, which makes this type universal for any event.
Adding and getting common.Position is implemented using the SetPosition and Position functions, which are wrappers of the event.SetData and event.Data functions.

For the server handler, a subscriber registration function has been added and the fireEvent method has been changed - now it also accepts a context.
The method now runs in a goroutine and does not return an error, but processes each error internally.
Added fireraiser type, which repeats the signature of the event.FireEvent function, and added retryFire function, which is called inside fireEvent.
It raises the event until the Handle method of the consumer (subscriber to this event) returns a nil error.
Each call occurs after twice the amount of time starting from 1 second.
Calls can be terminated by an initially specified number of retries, or when transmitted in the context of a deadline or timeout.